### PR TITLE
Changed HistoryDTO To contain a bool for feedback

### DIFF
--- a/HealthCareABApi/Controllers/HistoryController.cs
+++ b/HealthCareABApi/Controllers/HistoryController.cs
@@ -13,10 +13,12 @@ namespace HealthCareABApi.Controllers
     public class HistoryController : ControllerBase
     {
         private readonly IAppointmentRepository _AppointmentRepository;
+        private readonly IFeedbackRepository _FeedbackRepository;
 
         public HistoryController(IAppointmentRepository appointmentRepository, IFeedbackRepository feedbackRepository)
         {
             _AppointmentRepository = appointmentRepository;
+            _FeedbackRepository = feedbackRepository;
         }
 
         [Authorize(Roles = Roles.User)]
@@ -46,6 +48,9 @@ namespace HealthCareABApi.Controllers
                     return NotFound("No History Found For This User");
                 }
 
+                //Retrive feedbacks to check if appointment has feedback
+                var feedbacks = await _FeedbackRepository.GetByPatientIdAsync(userId);
+
                 List<HistoryDTO> HistoryDTOList = new();
 
                 foreach (var appointment in appointments)
@@ -56,7 +61,8 @@ namespace HealthCareABApi.Controllers
                             Id = appointment.Id,
                             PatientName = appointment.Patient?.Username ?? "Unknown",
                             CaregiverName = appointment.Caregiver?.Username ?? "Unknown",
-                            DateTime = appointment.DateTime
+                            DateTime = appointment.DateTime,
+                            HasFeedback = feedbacks.Any(f => f.AppointmentId == appointment.Id)
                         }
                     );
                 }

--- a/HealthCareABApi/DTO/HistoryDTO.cs
+++ b/HealthCareABApi/DTO/HistoryDTO.cs
@@ -8,5 +8,6 @@ namespace HealthCareABApi.DTO
         public string PatientName { get; set; }
         public string CaregiverName { get; set; }
         public DateTime DateTime { get; set; }
+        public bool HasFeedback { get; set; }
     }
 }

--- a/HealthCareABApi/Repositories/Implementations/FeedbackRepository.cs
+++ b/HealthCareABApi/Repositories/Implementations/FeedbackRepository.cs
@@ -29,6 +29,11 @@ namespace HealthCareABApi.Repositories.Implementations
             return await _Dbcontext.Feedback.Where(f => f.AppointmentId == id).FirstOrDefaultAsync();
         }
 
+        public async Task<IEnumerable<Feedback>> GetByPatientIdAsync(int id)
+        {
+            return await _Dbcontext.Feedback.Include(f => f.Appointment).Where(f => f.Appointment.PatientId == id).ToListAsync();
+        }
+
         public async Task CreateAsync(Feedback feedback)
         {
             await _Dbcontext.Feedback.AddAsync(feedback);

--- a/HealthCareABApi/Repositories/Interfaces/IFeedbackRepository.cs
+++ b/HealthCareABApi/Repositories/Interfaces/IFeedbackRepository.cs
@@ -11,6 +11,7 @@ namespace HealthCareABApi.Repositories
         Task CreateAsync(Feedback feedback);
         Task UpdateAsync(int id, Feedback feedback);
         Task DeleteAsync(int id);
+        Task<IEnumerable<Feedback>> GetByPatientIdAsync(int id);
     }
 }
 


### PR DESCRIPTION
Added a new implementation of GetByPatientIdAsync in FeedbackRepository.
Added a bool in HistoryDTO that tracks if appointment has feedback. 
Added logic to set if Feedback exists on a appointment in the HistoryDTO.

**This PR is dependent on "10-Skapa-Vy-För-Feedback" in the Frontend repository & both needs to be checked-out to be tested.** 

Acceptance-criteria: 
- Checkout this branch in the backend & "10-Skapa-Vy-För-Feedback" in the frontend. 
- Create a appointment and set the status to completed. 
- Go to the History page in the UserDashboard
- Submit feedback on the appointment & make sure the button get's disabled after submit. 