### PR TITLE
45 format times in availability and appointment

### DIFF
--- a/HealthCareABApi/Controllers/AvailabilityController.cs
+++ b/HealthCareABApi/Controllers/AvailabilityController.cs
@@ -8,7 +8,6 @@ using HealthCareABApi.Repositories.Interfaces;
 
 namespace HealthCareABApi.Controllers
 {
-    [Authorize(Roles = Roles.Admin)]
     [ApiController]
     [Route("api/[Controller]")]
     public class AvailabilityController : ControllerBase
@@ -35,7 +34,6 @@ namespace HealthCareABApi.Controllers
                 return BadRequest(ex.Message);
             }
         }
-
         [HttpGet("{caregiverId}")]
         public async Task<IActionResult> GetAvailabilitiesByCaregiverId(int caregiverId)
         {
@@ -55,7 +53,7 @@ namespace HealthCareABApi.Controllers
                 return StatusCode(500, new { Error = ex.Message });
             }
         }
-
+        [Authorize(Roles = Roles.Admin)]
         [HttpPost("CreateAvailibility")]
         public async Task<IActionResult> CreateAvailability([FromBody] CreateAvailabilityDTO availabilityDto)
         {
@@ -90,6 +88,7 @@ namespace HealthCareABApi.Controllers
                     Caregiver = caregiver,
                     StartTime = availabilityDto.StartTime.ToLocalTime(),
                     EndTime = availabilityDto.EndTime.ToLocalTime(),
+                    IsBooked = availabilityDto.IsBooked = false,
                 };
 
                 await _availabilityService.CreateAsync(availability);
@@ -100,7 +99,8 @@ namespace HealthCareABApi.Controllers
                 return StatusCode(500, new { Error = ex.Message });
             }
         }
-        [HttpPut]
+        [Authorize(Roles = Roles.Admin)]
+        [HttpPut("UpdateAvailability/{id}")] // Include the id in the route
         public async Task<IActionResult> UpdateAvailability(int id, [FromBody] CreateAvailabilityDTO availabilityDto)
         {
             if (availabilityDto.StartTime >= availabilityDto.EndTime)
@@ -135,8 +135,8 @@ namespace HealthCareABApi.Controllers
                     return NotFound("Availability not found.");
                 }
 
-                existingAvailability.StartTime = availabilityDto.StartTime;
-                existingAvailability.EndTime = availabilityDto.EndTime;
+                existingAvailability.StartTime = availabilityDto.StartTime.ToLocalTime();
+                existingAvailability.EndTime = availabilityDto.EndTime.ToLocalTime();
 
                 await _availabilityRepository.UpdateAsync(id, existingAvailability);
 
@@ -147,6 +147,7 @@ namespace HealthCareABApi.Controllers
                 return StatusCode(500, new { Error = ex.Message });
             }
         }
+        [Authorize(Roles = Roles.Admin)]
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteAvailability(int id)
         {

--- a/HealthCareABApi/DTO/AvailableSlotsDTO.cs
+++ b/HealthCareABApi/DTO/AvailableSlotsDTO.cs
@@ -2,10 +2,11 @@
 {
     public class AvailableSlotsDTO
     {
-        public Guid SlotId { get; set; }
+        public int Id { get; set; }
         public int CaregiverId { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
         public bool IsBooked { get; set; }
+        public int AppointmentId { get; set; }
     }
 }

--- a/HealthCareABApi/Models/Availability.cs
+++ b/HealthCareABApi/Models/Availability.cs
@@ -1,12 +1,12 @@
-﻿namespace HealthCareABApi.Models
+﻿using HealthCareABApi.Models;
+
+public class Availability
 {
-    public class Availability
-    {
-        public int Id { get; set; }
-        public User Caregiver { get; set; }
-        public Appointment? Appointment { get; set; }
-        public DateTime StartTime { get; set; }
-        public DateTime EndTime { get; set; }
-        public bool IsBooked { get; set; } = false;
-    }
+    public int Id { get; set; }
+    public User Caregiver { get; set; }
+    public int? AppointmentId { get; set; }
+    public Appointment? Appointment { get; set; }
+    public DateTime StartTime { get; set; }
+    public DateTime EndTime { get; set; }
+    public bool IsBooked { get; set; } = false;
 }

--- a/HealthCareABApi/Repositories/Implementations/AppointmentRepository.cs
+++ b/HealthCareABApi/Repositories/Implementations/AppointmentRepository.cs
@@ -24,7 +24,10 @@ namespace HealthCareABApi.Repositories.Implementations
 
         public async Task<Appointment> GetByIdAsync(int id)
         {
-            return await _Dbcontext.Appointment.Where(a => a.Id == id).FirstAsync();
+            return await _Dbcontext.Appointment
+                .Include(a => a.Caregiver)
+                .Include(a => a.Patient)
+                .FirstOrDefaultAsync(a => a.Id == id);
         }
 
         public async Task<IEnumerable<Appointment>> GetByUserIdAsync(int patientId)

--- a/HealthCareABApi/Repositories/Implementations/AvailabilityRepository.cs
+++ b/HealthCareABApi/Repositories/Implementations/AvailabilityRepository.cs
@@ -80,7 +80,11 @@ namespace HealthCareABApi.Repositories.Implementations
 
         public async Task<IEnumerable<Availability>> GetByCaregiverIdAsync(int caregiverId)
         {
-            return await _Dbcontext.Availability.Include(x => x.Caregiver).Where(a => a.Caregiver.Id == caregiverId).ToListAsync();
+            return await _Dbcontext.Availability
+                .Include(a => a.Caregiver)
+                .Include(a => a.Appointment) // Include the Appointment navigation property
+                .Where(a => a.Caregiver.Id == caregiverId)
+                .ToListAsync();
         }
     }
 }

--- a/HealthCareABApi/Services/AppointmentService.cs
+++ b/HealthCareABApi/Services/AppointmentService.cs
@@ -97,7 +97,7 @@ namespace HealthCareABApi.Services
                     throw new KeyNotFoundException("Appointment not found.");
                 }
 
-            return appointment;
+                    return appointment;
                 }
 
         public async Task<IEnumerable<DetailedResponseDTO>> GetByUserIdAsync(int patientId)
@@ -116,13 +116,13 @@ namespace HealthCareABApi.Services
                 DetailedResponses.Add(
                     new DetailedResponseDTO
                 {
-                    Id = appointment.Id,
+                        Id = appointment.Id,
                         PatientId = patientId,
                         PatientName = appointment.Patient.Username, // Add name prop later maybe
-                    CaregiverId = appointment.CaregiverId,
+                        CaregiverId = appointment.CaregiverId,
                         CaregiverName = appointment.Caregiver.Username,
                         AppointmentTime = appointment.DateTime,
-                    Status = appointment.Status,
+                        Status = appointment.Status,
                     }
                 );
             }

--- a/HealthCareABApi/Services/AppointmentService.cs
+++ b/HealthCareABApi/Services/AppointmentService.cs
@@ -27,7 +27,7 @@ namespace HealthCareABApi.Services
                 {
                     PatientId = dto.PatientId,
                     CaregiverId = dto.CaregiverId,
-                    DateTime = dto.AppointmentTime,
+                    DateTime = dto.AppointmentTime.ToLocalTime(),
                     Status = AppointmentStatus.Scheduled
                 };
 
@@ -90,15 +90,15 @@ namespace HealthCareABApi.Services
 
         public async Task<Appointment> GetByIdAsync(int id)
         {
-            var appointment = await _appointmentRepository.GetByIdAsync(id);
+                var appointment = await _appointmentRepository.GetByIdAsync(id);
 
-            if (appointment == null)
-            {
-                throw new KeyNotFoundException("Appointment not found.");
-            }
+                if (appointment == null)
+                {
+                    throw new KeyNotFoundException("Appointment not found.");
+                }
 
             return appointment;
-        }
+                }
 
         public async Task<IEnumerable<DetailedResponseDTO>> GetByUserIdAsync(int patientId)
         {
@@ -115,14 +115,14 @@ namespace HealthCareABApi.Services
             {
                 DetailedResponses.Add(
                     new DetailedResponseDTO
-                    {
-                        Id = appointment.Id,
+                {
+                    Id = appointment.Id,
                         PatientId = patientId,
                         PatientName = appointment.Patient.Username, // Add name prop later maybe
-                        CaregiverId = appointment.CaregiverId,
+                    CaregiverId = appointment.CaregiverId,
                         CaregiverName = appointment.Caregiver.Username,
                         AppointmentTime = appointment.DateTime,
-                        Status = appointment.Status,
+                    Status = appointment.Status,
                     }
                 );
             }

--- a/HealthCareABApi/Services/AvailabilityService.cs
+++ b/HealthCareABApi/Services/AvailabilityService.cs
@@ -64,7 +64,7 @@ namespace HealthCareABApi.Services
                     EndTime = slot.EndTime,
                     CaregiverId = slot.Caregiver.Id,
                     IsBooked = slot.IsBooked,
-                    AppointmentId = slot.Appointment?.Id ?? 0 // Check for null
+                    AppointmentId = slot.Appointment?.Id ?? 0 // This should now correctly map the AppointmentId
                 }).ToList();
 
                 return availableSlots;

--- a/HealthCareABApi/Services/AvailabilityService.cs
+++ b/HealthCareABApi/Services/AvailabilityService.cs
@@ -59,9 +59,12 @@ namespace HealthCareABApi.Services
                 // Map the data to AvailableSlotsDTO
                 var availableSlots = allAvailabilities.Select(slot => new AvailableSlotsDTO
                 {
+                    Id = slot.Id,
                     StartTime = slot.StartTime,
                     EndTime = slot.EndTime,
-                    CaregiverId = slot.Caregiver.Id
+                    CaregiverId = slot.Caregiver.Id,
+                    IsBooked = slot.IsBooked,
+                    AppointmentId = slot.Appointment?.Id ?? 0 // Check for null
                 }).ToList();
 
                 return availableSlots;
@@ -97,12 +100,11 @@ namespace HealthCareABApi.Services
             {
                 var slot = new Availability
                 {
-                    StartTime = currentStartTime,
-                    EndTime = currentStartTime.AddMinutes(30),
+                    StartTime = DateTime.Parse(currentStartTime.ToString("yyyy-MM-dd HH:mm:ss")),
+                    EndTime = DateTime.Parse(currentStartTime.AddMinutes(30).ToString("yyyy-MM-dd HH:mm:ss")),
                     Caregiver = availability.Caregiver
                 };
 
-                // Check if the slot already exists
                 var existingSlot = await _Dbcontext.Availability
                     .FirstOrDefaultAsync(s => s.StartTime == slot.StartTime && s.Caregiver.Id == slot.Caregiver.Id);
 


### PR DESCRIPTION
- Removed slotId prop from AvailableSlotsDTO
- Removed [Authorize] from the AvailabilityController
- Formatted time saved into the database

- Added int Id to AvailableSlotsDTO
- Added AppointmentId to AvailableSlotsDTO

- Sent more information to front when fetching by caregiverId

- Added [Authorize] to endpoints where users should not have auth

--Acceptance criteria--

Start- and endtimes should be saved with format "yyyy-MM-ddThh:mm:ss" in database to remove risk of double bookings when creating and updating available timeslots.
