### PR TITLE
46 group duplicate time slots in backend to display only one time slot in client

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -79,7 +79,7 @@ namespace HealthCareABApi.Controllers
             try
             {
                 await _appointmentService.DeleteAsync(id);
-                return NoContent(); // kod 204 = lyckad delete
+                return Ok();
             }
             catch (KeyNotFoundException)
             {
@@ -103,7 +103,7 @@ namespace HealthCareABApi.Controllers
             try
             {
                 await _appointmentService.UpdateAsync(dto);
-                return NoContent();  // kod 204 - lyckda update
+                return Ok();
             }
             catch (KeyNotFoundException)
             {

--- a/HealthCareABApi/Controllers/AvailabilityController.cs
+++ b/HealthCareABApi/Controllers/AvailabilityController.cs
@@ -34,6 +34,22 @@ namespace HealthCareABApi.Controllers
                 return BadRequest(ex.Message);
             }
         }
+
+        [Authorize(Roles = Roles.User)]
+        [HttpGet("getuniqueslots")]
+        public async Task<IActionResult> GetUniqueSlots()
+        {
+            try
+            {
+                var uniqueSlots = await _availabilityService.GetUniqueSlotsAsync();
+                return Ok(uniqueSlots);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, ex.Message);
+            }
+        }
+
         [HttpGet("{caregiverId}")]
         public async Task<IActionResult> GetAvailabilitiesByCaregiverId(int caregiverId)
         {

--- a/HealthCareABApi/DTO/UniqueSlotsDTO.cs
+++ b/HealthCareABApi/DTO/UniqueSlotsDTO.cs
@@ -1,0 +1,15 @@
+﻿namespace HealthCareABApi.DTO
+{
+    public class UniqueSlotsDTO
+    {
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+        public List<CaregiverDTO> Caregivers { get; set; }
+    }
+
+    public class CaregiverDTO
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/HealthCareABApi/Repositories/Interfaces/IAvailabilityService.cs
+++ b/HealthCareABApi/Repositories/Interfaces/IAvailabilityService.cs
@@ -6,6 +6,7 @@ namespace HealthCareABApi.Repositories.Interfaces
     public interface IAvailabilityService
     {
         Task<IEnumerable<AvailableSlotsDTO>> GetAllAsync();
+        Task<IEnumerable<UniqueSlotsDTO>> GetUniqueSlotsAsync();
         Task<IEnumerable<AvailableSlotsDTO>> GetByCaregiverIdAsync(int caregiverId);
         Task CreateAsync(Availability availability);
         Task DeleteAsync(int id);

--- a/HealthCareAb-Tests/AppointmentControllerTests.cs
+++ b/HealthCareAb-Tests/AppointmentControllerTests.cs
@@ -176,7 +176,7 @@ namespace HealthCareAb_Tests
         }
 
         [Fact]
-        public async Task DeleteAppointment_ReturnsNoContent()
+        public async Task DeleteAppointment_ReturnsOkWhenAppointmentIsDeleted()
         {
             // Arrange
             _mockService.Setup(service => service.DeleteAsync(1)).Returns(Task.CompletedTask);
@@ -185,7 +185,7 @@ namespace HealthCareAb_Tests
             var result = await _controller.DeleteAppointment(1);
 
             // Assert
-            Assert.IsType<NoContentResult>(result);
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]
@@ -202,14 +202,14 @@ namespace HealthCareAb_Tests
         }
 
         [Fact]
-        public async Task UpdateAppointment_ReturnsNoContent()
+        public async Task UpdateAppointment_ReturnsOkWhenAppointmentIsCUpdated()
         {
             // Arrange
             var updateAppointmentDTO = new UpdateAppointmentDTO
             {
                 CaregiverId = 2,
                 AppointmentTime = DateTime.Now.AddHours(1),
-                Status = AppointmentStatus.Completed
+                Status = AppointmentStatus.Scheduled
             };
 
             _mockService.Setup(service => service.UpdateAsync(updateAppointmentDTO)).Returns(Task.CompletedTask);
@@ -218,7 +218,7 @@ namespace HealthCareAb_Tests
             var result = await _controller.UpdateAppointment(updateAppointmentDTO);
 
             // Assert
-            Assert.IsType<NoContentResult>(result);
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]


### PR DESCRIPTION
To test this:

**Swagger**: Call endpoint "getuniqueslots" and check response.

** Frontend**:
1. Make sure issue #59 is pulled
3. Login as user (make sure caregivers has created availabilities at same time periods)
4. Go to Book Appointment and choose a time slot
5. Try book appointment without choosing caregiver
6. Choose caregiver and book appointment
7. Check db for correct data insertion

Leave a lovely comment <3