### PR TITLE
Implemented background service to remove expired availability records daily

### DIFF
--- a/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
+++ b/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
@@ -10,11 +10,6 @@ namespace HealthCareABApi.BackgroundJobs
         private readonly IServiceProvider _services = services;
         private readonly TimeSpan _runTime = new(2, 0, 0); // kl 02:00
 
-        public async Task RunCleanupAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             while (!stoppingToken.IsCancellationRequested)

--- a/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
+++ b/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
@@ -8,7 +8,12 @@ namespace HealthCareABApi.BackgroundJobs
     public class CleanupSlotsService(IServiceProvider services) : BackgroundService
     {
         private readonly IServiceProvider _services = services;
-        private readonly TimeSpan _runTime = new(11, 54, 0); // kl 02:00
+        private readonly TimeSpan _runTime = new(2, 0, 0); // kl 02:00
+
+        public async Task RunCleanupAsync()
+        {
+            throw new NotImplementedException();
+        }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {

--- a/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
+++ b/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
@@ -1,0 +1,61 @@
+﻿
+using HealthCareABApi.Repositories.Data;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace HealthCareABApi.BackgroundJobs
+{
+    // Service that cleans up expired availability slots in db daily at specific time (default: 02:00)
+    public class CleanupSlotsService(IServiceProvider services) : BackgroundService
+    {
+        private readonly IServiceProvider _services = services;
+        private readonly TimeSpan _runTime = new(11, 54, 0); // kl 02:00
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var currentTime = DateTime.Now;
+                var nextRun = GetNextRun(currentTime);
+
+                await Task.Delay(nextRun - currentTime, stoppingToken); // Wait until next scheduled runtime
+
+                using (var scope = _services.CreateScope())
+                {
+                    try
+                    {
+                        var dbContext = scope.ServiceProvider.GetRequiredService<HealthCareDbContext>();
+
+                        var expiredSlots = dbContext.Availability.Where(a => a.EndTime < currentTime).ToList();
+
+                        if (expiredSlots.Count != 0)
+                        {
+                            dbContext.RemoveRange(expiredSlots);
+                            await dbContext.SaveChangesAsync(stoppingToken);
+
+                            Console.WriteLine($"Deleted {expiredSlots.Count} expired slots today - {DateTime.Now:yyyy-MM-dd}"); // Maybe good to know if we would use logger
+                        }
+
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Error during cleanup: {ex.Message}");
+                    }
+                }
+            }
+        }
+
+        private DateTime GetNextRun(DateTime currentTime)
+        {
+            // Calculate next scheduled runtime based on "_runtime". 
+            var nextRun = new DateTime(currentTime.Year, currentTime.Month, currentTime.Day, _runTime.Hours, _runTime.Minutes, _runTime.Seconds); // t ex 2025-01-20 02:00:00
+
+            // If current time has passed, schedule for same time tomorrow
+            if (currentTime > nextRun)
+            {
+                nextRun = nextRun.AddDays(1);
+            }
+
+            return nextRun;
+        }
+    }
+}

--- a/HealthCareABApi/Program.cs
+++ b/HealthCareABApi/Program.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Hosting;
 using HealthCareABApi.Repositories.Interfaces;
+using HealthCareABApi.BackgroundJobs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,6 +29,7 @@ builder.Services.AddScoped<IRoleService, RoleService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IJwtTokenService, JwtTokenService>();
 
+builder.Services.AddHostedService<CleanupSlotsService>();
 
 // Add controllers
 builder.Services.AddControllers();

--- a/HealthCareAb-Tests/BackgroundServiceTests.cs
+++ b/HealthCareAb-Tests/BackgroundServiceTests.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using HealthCareABApi.BackgroundJobs;
+using HealthCareABApi.Repositories.Data;
+using HealthCareABApi.Models;
+using System.Diagnostics;
+
+namespace HealthCareAb_Tests
+{
+    public class CleanupSlotsServiceTests : IDisposable
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly HealthCareDbContext _dbContext;
+
+        public CleanupSlotsServiceTests()
+        {
+            var services = new ServiceCollection();
+
+            services.AddDbContext<HealthCareDbContext>(options =>
+                options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()),
+                ServiceLifetime.Scoped);
+
+            _serviceProvider = services.BuildServiceProvider();
+            _dbContext = _serviceProvider.GetRequiredService<HealthCareDbContext>();
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WhenExpiredSlotsExist_DeletesThem()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<HealthCareDbContext>()
+                .UseInMemoryDatabase(databaseName: "TestDatabase")
+                .Options;
+
+            using (var dbContext = new HealthCareDbContext(options))
+            {
+                var currentTime = DateTime.Now;
+                var slotStart = currentTime.AddDays(-2); // Starttid är 2 dagar tidigare
+                var expiredSlots = new List<Availability>
+                {
+                    new Availability
+                    {
+                        Caregiver = new User { Id = 1, Username = "Caregiver 1", PasswordHash = "123" },
+                        StartTime = slotStart,
+                        EndTime = slotStart.AddMinutes(30), // EndTime är 30 minuter efter StartTime
+                        IsBooked = false
+                    },
+                    new Availability
+                    {
+                        Caregiver = new User { Id = 2, Username = "Caregiver 2", PasswordHash = "321" },
+                        StartTime = slotStart.AddDays(1),
+                        EndTime = slotStart.AddDays(1).AddMinutes(30), // EndTime är 30 minuter efter StartTime
+                        IsBooked = false
+                    }
+                };
+
+                await dbContext.Availability.AddRangeAsync(expiredSlots);
+                await dbContext.SaveChangesAsync();
+
+                // Debugging-syfte
+                var slotsInDb = await dbContext.Availability.ToListAsync();
+                foreach (var slot in slotsInDb)
+                {
+                    Debug.WriteLine($"Id: {slot.Id}, StartTime: {slot.StartTime}, EndTime: {slot.EndTime}, IsBooked: {slot.IsBooked}");
+                }
+
+                // Kolla så att slots sparats i db
+                var slotsBeforeCleanup = await dbContext.Availability.CountAsync();
+                Assert.Equal(2, slotsBeforeCleanup);
+
+                // Act
+                var expiredSlotsToDelete = dbContext.Availability.Where(a => a.EndTime < currentTime).ToList();
+                dbContext.RemoveRange(expiredSlotsToDelete);
+                await dbContext.SaveChangesAsync();
+
+                // Assert
+                var remainingSlots = await dbContext.Availability.ToListAsync();
+                Assert.Empty(remainingSlots);
+            }
+        }
+
+        [Fact]
+        public void GetNextRun_WhenCurrentTimeBeforeRunTime_ReturnsNextRunToday()
+        {
+            // Arrange
+            var service = new CleanupSlotsService(_serviceProvider);
+            var currentTime = new DateTime(2025, 1, 14, 1, 0, 0); // 01:00
+            var expectedNextRun = new DateTime(2025, 1, 14, 2, 0, 0); // 02:00 same day
+
+            // Act (använder reflektion för att testa private methods)
+            var result = service.GetType()
+                .GetMethod("GetNextRun", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .Invoke(service, new object[] { currentTime });
+
+            // Assert
+            Assert.Equal(expectedNextRun, result);
+        }
+
+        [Fact]
+        public void GetNextRun_WhenCurrentTimeAfterRunTime_ReturnsNextRunTomorrow()
+        {
+            // Arrange
+            var service = new CleanupSlotsService(_serviceProvider);
+            var currentTime = new DateTime(2025, 1, 14, 3, 0, 0); // 03:00
+            var expectedNextRun = new DateTime(2025, 1, 15, 2, 0, 0); // 02:00 next day
+
+            // Act
+            var result = service.GetType()
+                .GetMethod("GetNextRun", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .Invoke(service, new object[] { currentTime });
+
+            // Assert
+            Assert.Equal(expectedNextRun, result);
+        }
+
+        public void Dispose() // Rensar db efter varje test
+        {
+            _dbContext.Database.EnsureDeleted();
+            _dbContext.Dispose();
+        }
+    }
+}

--- a/HealthCareAb-Tests/HealthCareAb-Tests.csproj
+++ b/HealthCareAb-Tests/HealthCareAb-Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />


### PR DESCRIPTION
Background service that runs every days at 02:00 to check and delete availability records that has expired.
Tests added.

**To test this**:
1. Ensure you have availability records where EndTime has expired.
2. Set the time in the TimeSpan field to 1 or 2 minutes ahead of your current time on computer:  
**private readonly TimeSpan _runTime = new(2, 0, 0); // kl 02:00**. Change "(2, 0, 0)" to "(15, 30, 0)" if your clock is 15:28, for example.
3. Wait 1 or 2 minutes.
4. Check db to ensure expired availability records has been removed.
5. Approve this PR