### PR TITLE
Prevent patient to book appointment at existing appointment time

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -32,7 +32,7 @@ namespace HealthCareABApi.Controllers
             }
             catch (InvalidOperationException ex)
             {
-                return BadRequest("No availability was found for this caregiver");
+                return BadRequest(new {message = ex.Message });
             }
             catch (Exception)
             {

--- a/HealthCareABApi/Repositories/Implementations/AppointmentRepository.cs
+++ b/HealthCareABApi/Repositories/Implementations/AppointmentRepository.cs
@@ -30,6 +30,17 @@ namespace HealthCareABApi.Repositories.Implementations
                 .FirstOrDefaultAsync(a => a.Id == id);
         }
 
+        public async Task<Appointment> GetByPatientAndTimeAsync(int patientId, DateTime appointmentTime)
+        {
+            var localTime = appointmentTime.ToLocalTime(); // Konvertera till lokal tid
+
+            return await _Dbcontext.Appointment
+                .FirstOrDefaultAsync(a =>
+                    a.PatientId == patientId &&
+                    EF.Functions.DateDiffSecond(a.DateTime, localTime) == 0 && // Ignorerar millisekunder i databasen och kollar tiden på sekundnivå
+                    a.Status == AppointmentStatus.Scheduled);
+        }
+
         public async Task<IEnumerable<Appointment>> GetByUserIdAsync(int patientId)
         {
             return await _Dbcontext.Appointment

--- a/HealthCareABApi/Repositories/Interfaces/IAppointmentRepository.cs
+++ b/HealthCareABApi/Repositories/Interfaces/IAppointmentRepository.cs
@@ -11,6 +11,7 @@ namespace HealthCareABApi.Repositories
         Task<bool> UpdateAsync(int id, Appointment appointment);
         Task DeleteAsync(int id);
         Task<IEnumerable<Appointment>> GetByUserIdAsync(int patientId);
+        Task<Appointment> GetByPatientAndTimeAsync(int patientId, DateTime appointmentTime);
     }
 }
 

--- a/HealthCareABApi/Services/AppointmentService.cs
+++ b/HealthCareABApi/Services/AppointmentService.cs
@@ -24,6 +24,12 @@ namespace HealthCareABApi.Services
                 throw new ArgumentNullException(nameof(dto), "CreateAppointmentDTO cannot be null");
             }
 
+            var existingAppointment = await _appointmentRepository.GetByPatientAndTimeAsync(dto.PatientId, dto.AppointmentTime);
+            if (existingAppointment != null)
+            {
+                throw new InvalidOperationException("You already have a scheduled appointment at this time.");
+            }
+
             try
             {
                 var appointment = new Appointment


### PR DESCRIPTION
- Added logic to check if patient has an existing appointment at same date/time if trying to book with another caregiver
- Modified exception message so it's shown in frontend when an existing appointment is found

**To test**:
Frontend app:
1. Create availabilities at the same time with two separate caregivers
2. Book appointment with one caregiver
3. Try book appointment with another caregiver at the same time and day.

**Acceptance criteria**:
Patient should not be able to book an appointment with another caregiver at the same time and date as an existing appointment.
Recieve error message saying you already have an appointment.

Unsure how to test this in swagger since timezone f****s it up..........

