### PR TITLE
Create user dashboard logic (and background service cleanup fix)

### DIFF
--- a/HealthCareABApi/Controllers/AppointmentController.cs
+++ b/HealthCareABApi/Controllers/AppointmentController.cs
@@ -115,12 +115,12 @@ namespace HealthCareABApi.Controllers
             }
         }
 
-        [HttpGet("getappointmentsbypatientid/{patientId}")]
-        public async Task<IActionResult> GetByUserId(int patientId)
+        [HttpGet("getcompletedappointmentsbyuserid/{userId}")]
+        public async Task<IActionResult> GetByUserId(int userId)
         {
             try
             {
-                var appointments = await _appointmentService.GetByUserIdAsync(patientId);
+                var appointments = await _appointmentService.GetCompletedByUserIdAsync(userId);
                 return Ok(appointments);
             }
             catch (KeyNotFoundException)
@@ -133,5 +133,23 @@ namespace HealthCareABApi.Controllers
             }
         }
 
+        [Authorize(Roles = Roles.User)]
+        [HttpGet("getscheduledappointments/{userId}")]
+        public async Task<IActionResult> GetScheduledAppointments(int userId)
+        {
+            try
+            {
+                var scheduledAppointments = await _appointmentService.GetScheduledAppointmentsAsync(userId);
+                return Ok(scheduledAppointments);
+            }
+            catch (KeyNotFoundException)
+            {
+                return BadRequest();
+            }
+            catch (Exception)
+            {
+                return StatusCode(500, "Error processing GET method at api/getscheduledappointments");
+            }
+        }
     }
 }

--- a/HealthCareABApi/Controllers/HistoryController.cs
+++ b/HealthCareABApi/Controllers/HistoryController.cs
@@ -41,7 +41,7 @@ namespace HealthCareABApi.Controllers
                     return BadRequest("User Id is not valid");
                 }
 
-                var appointments = await _AppointmentRepository.GetByUserIdAsync(userId);
+                var appointments = await _AppointmentRepository.GetCompletedByUserIdAsync(userId);
 
                 if (appointments == null)
                 {

--- a/HealthCareABApi/DTO/ScheduledAppointmentsDTO.cs
+++ b/HealthCareABApi/DTO/ScheduledAppointmentsDTO.cs
@@ -1,0 +1,10 @@
+﻿namespace HealthCareABApi.DTO
+{
+    public class ScheduledAppointmentsDTO
+    {
+        public int Id { get; set; }
+        public DateTime AppointmentTime { get; set; }
+        public string CaregiverName { get; set; }
+        public string PatientName { get; set; }
+    }
+}

--- a/HealthCareABApi/DTO/UniqueSlotsDTO.cs
+++ b/HealthCareABApi/DTO/UniqueSlotsDTO.cs
@@ -2,6 +2,7 @@
 {
     public class UniqueSlotsDTO
     {
+        public int Id { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
         public List<CaregiverDTO> Caregivers { get; set; }

--- a/HealthCareABApi/Repositories/Interfaces/IAppointmentRepository.cs
+++ b/HealthCareABApi/Repositories/Interfaces/IAppointmentRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using HealthCareABApi.DTO;
 using HealthCareABApi.Models;
 
 namespace HealthCareABApi.Repositories
@@ -10,8 +11,9 @@ namespace HealthCareABApi.Repositories
         Task CreateAsync(Appointment appointment);
         Task<bool> UpdateAsync(int id, Appointment appointment);
         Task DeleteAsync(int id);
-        Task<IEnumerable<Appointment>> GetByUserIdAsync(int patientId);
+        Task<IEnumerable<Appointment>> GetCompletedByUserIdAsync(int userId);
         Task<Appointment> GetByPatientAndTimeAsync(int patientId, DateTime appointmentTime);
+        Task<IEnumerable<Appointment>> GetScheduledAppointmentsAsync(int userId);
     }
 }
 

--- a/HealthCareABApi/Repositories/Interfaces/IAppointmentService.cs
+++ b/HealthCareABApi/Repositories/Interfaces/IAppointmentService.cs
@@ -9,7 +9,8 @@ namespace HealthCareABApi.Repositories.Interfaces
         Task<Appointment> GetByIdAsync(int id);
         Task UpdateAsync(UpdateAppointmentDTO dto);
         Task DeleteAsync(int id);
-        Task<IEnumerable<DetailedResponseDTO>> GetByUserIdAsync(int patientId);
+        Task<IEnumerable<DetailedResponseDTO>> GetCompletedByUserIdAsync(int userId);
         Task<IEnumerable<GetAllAppointmentsDTO>> GetAllAsync();
+        Task<IEnumerable<ScheduledAppointmentsDTO>> GetScheduledAppointmentsAsync(int userId);
     }
 }

--- a/HealthCareABApi/Services/AppointmentService.cs
+++ b/HealthCareABApi/Services/AppointmentService.cs
@@ -40,7 +40,7 @@ namespace HealthCareABApi.Services
                     Status = AppointmentStatus.Scheduled
                 };
 
-                await _appointmentRepository.CreateAsync(appointment);
+                 await _appointmentRepository.CreateAsync(appointment);
 
                 return new AppointmentResponseDTO
                 {
@@ -99,19 +99,19 @@ namespace HealthCareABApi.Services
 
         public async Task<Appointment> GetByIdAsync(int id)
         {
-                var appointment = await _appointmentRepository.GetByIdAsync(id);
+            var appointment = await _appointmentRepository.GetByIdAsync(id);
 
-                if (appointment == null)
-                {
-                    throw new KeyNotFoundException("Appointment not found.");
-                }
+            if (appointment == null)
+            {
+                throw new KeyNotFoundException("Appointment not found.");
+            }
 
-                    return appointment;
-                }
+            return appointment;
+        }
 
-        public async Task<IEnumerable<DetailedResponseDTO>> GetByUserIdAsync(int patientId)
+        public async Task<IEnumerable<DetailedResponseDTO>> GetCompletedByUserIdAsync(int userId)
         {
-            var appointments = await _appointmentRepository.GetByUserIdAsync(patientId);
+            var appointments = await _appointmentRepository.GetCompletedByUserIdAsync(userId);
 
             if (appointments == null)
             {
@@ -124,9 +124,9 @@ namespace HealthCareABApi.Services
             {
                 DetailedResponses.Add(
                     new DetailedResponseDTO
-                {
+                    {
                         Id = appointment.Id,
-                        PatientId = patientId,
+                        PatientId = userId,
                         PatientName = appointment.Patient.Firstname + " " + appointment.Patient.Lastname,
                         CaregiverId = appointment.Caregiver.Id,
                         CaregiverName = appointment.Caregiver.Firstname + " " + appointment.Caregiver.Lastname,
@@ -137,6 +137,24 @@ namespace HealthCareABApi.Services
             }
 
             return DetailedResponses;
+        }
+
+        public async Task<IEnumerable<ScheduledAppointmentsDTO>> GetScheduledAppointmentsAsync(int patientId)
+        {
+            var appointments = await _appointmentRepository.GetScheduledAppointmentsAsync(patientId);
+
+            if (appointments == null || !appointments.Any())
+            {
+                throw new KeyNotFoundException($"{nameof(patientId)} has no scheduled appointments.");
+            }
+
+            return appointments.Select(appointment => new ScheduledAppointmentsDTO
+            {
+                Id = appointment.Id,
+                AppointmentTime = appointment.DateTime,
+                CaregiverName = string.Join(" ", appointment.Caregiver.Firstname, appointment.Caregiver.Lastname),
+                PatientName = string.Join(" ", appointment.Patient.Firstname, appointment.Patient.Lastname)
+            }).ToList();
         }
 
         public async Task UpdateAsync(UpdateAppointmentDTO dto)

--- a/HealthCareABApi/Services/AvailabilityService.cs
+++ b/HealthCareABApi/Services/AvailabilityService.cs
@@ -4,6 +4,7 @@ using HealthCareABApi.Repositories;
 using HealthCareABApi.Repositories.Data;
 using HealthCareABApi.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Principal;
 
 namespace HealthCareABApi.Services
 {
@@ -61,8 +62,9 @@ namespace HealthCareABApi.Services
 
                 var uniqueSlots = availableSlots
                     .GroupBy(s => new { s.StartTime })
-                    .Select(g => new UniqueSlotsDTO
+                    .Select((g, index) => new UniqueSlotsDTO
                     {
+                        Id = index + 1,
                         StartTime = g.Key.StartTime,
                         EndTime = g.First().EndTime, // endtime always the same for each group since we add 30 mins to start. With various endtimes on slots we'd have to group endtime as well.
                         Caregivers = g.Select(s => new CaregiverDTO

--- a/HealthCareAb-Tests/AppointmentControllerTests.cs
+++ b/HealthCareAb-Tests/AppointmentControllerTests.cs
@@ -258,7 +258,7 @@ namespace HealthCareAb_Tests
                 }
             };
 
-            _mockService.Setup(service => service.GetByUserIdAsync(1)).ReturnsAsync(detailedResponseDTOList);
+            _mockService.Setup(service => service.GetCompletedByUserIdAsync(1)).ReturnsAsync(detailedResponseDTOList);
 
             // Act
             var result = await _controller.GetByUserId(1);
@@ -273,7 +273,7 @@ namespace HealthCareAb_Tests
         public async Task GetAppointmentByPatientId_ReturnsNotFoundWhenAppointmentDoesNotExist()
         {
             // Arrange
-            _mockService.Setup(service => service.GetByUserIdAsync(1)).ThrowsAsync(new KeyNotFoundException());
+            _mockService.Setup(service => service.GetCompletedByUserIdAsync(1)).ThrowsAsync(new KeyNotFoundException());
 
             // Act
             var result = await _controller.GetByUserId(1);

--- a/HealthCareAb-Tests/HistoryControllerTests.cs
+++ b/HealthCareAb-Tests/HistoryControllerTests.cs
@@ -67,7 +67,7 @@ namespace HealthCareAb_Tests
             // Arrange
             var userId = 1;
             SetupUser(userId.ToString());
-            _mockAppointmentRepository.Setup(repo => repo.GetByUserIdAsync(userId)).ReturnsAsync((List<Appointment>)null);
+            _mockAppointmentRepository.Setup(repo => repo.GetCompletedByUserIdAsync(userId)).ReturnsAsync((List<Appointment>)null);
 
             // Act
             var result = await _historyController.GetAppointmentsForHistory();
@@ -83,7 +83,7 @@ namespace HealthCareAb_Tests
             // Arrange
             var userId = 1;
             SetupUser(userId.ToString());
-            _mockAppointmentRepository.Setup(repo => repo.GetByUserIdAsync(userId))
+            _mockAppointmentRepository.Setup(repo => repo.GetCompletedByUserIdAsync(userId))
                 .ThrowsAsync(new Exception());
 
             // Act


### PR DESCRIPTION
- Added index to grouped slots
- Created endpoint to get scheduled appointments
- Modified method Name "GetCompletedByUserIdAsync" to reflect what it really does.
- Initialized cleanup in availability table on server start

To test:
Pull this branch, and pull branch 30 i frontend (create-user-dashboard)

Backend:
Make sure old available slots is deleted in db.

In frontend:
Ensure you see upcoming appointments
Ensure dashboard only displays today's available slots and not slots that has passed current time
Ensure you see historic appointments
Book an appointment on the "Today's available times" card.
Ensure the newly booked appointment shows in Upcoming appointments.
Delete a booked appointment.
Ensure it is deleted in db.