### PR TITLE
Only delete old Availabilities that doesn't have an appointment.

### DIFF
--- a/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
+++ b/HealthCareABApi/BackgroundJobs/CleanupSlotsService.cs
@@ -21,7 +21,8 @@ namespace HealthCareABApi.BackgroundJobs
                     var initialDbContext = initialScope.ServiceProvider.GetRequiredService<HealthCareDbContext>();
                     var currentTime = DateTime.Now;
 
-                    var expiredSlots = initialDbContext.Availability.Where(a => a.EndTime < currentTime).ToList();
+                    // Fetch slots without an appointment
+                    var expiredSlots = initialDbContext.Availability.Where(a => a.EndTime < currentTime && a.IsBooked != true).ToList();
 
                     if (expiredSlots.Any())
                     {


### PR DESCRIPTION
- Added IsBooked bool to daily deletion so that caregivers can change status on the appointment. 

--Acceptance Criteria--
- Clone the branch, make some old availabilities & book them. Restart the application and make sure they are not deleted.